### PR TITLE
Migrate timing API to std::chrono::milliseconds

### DIFF
--- a/headers/UtilsQt/Futures/SignalToFuture.h
+++ b/headers/UtilsQt/Futures/SignalToFuture.h
@@ -83,12 +83,4 @@ QFuture<ResultType> signalToFuture(Object* object, void (Object::* signal)(Args.
     return promise.future();
 }
 
-template<typename Object, typename... Args,
-         typename ResultType = typename Internal::ResultProvider<Args...>::ReturnType,
-         typename std::enable_if<std::is_base_of<QObject, Object>::value>::type* = nullptr>
-QFuture<ResultType> signalToFuture(Object* object, void (Object::* signal)(Args...), QObject* context, unsigned long timeout)
-{
-    return signalToFuture(object, signal, context, std::chrono::milliseconds(timeout));
-}
-
 } // namespace UtilsQt

--- a/headers/UtilsQt/Futures/Utils.h
+++ b/headers/UtilsQt/Futures/Utils.h
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <memory>
 #include <exception>
+#include <chrono>
 #include <QObject>
 #include <QFuture>
 #include <QFutureInterface>
@@ -67,9 +68,9 @@
  * QFuture<T> createCanceledFuture<T>();
  * QFuture<T> createExceptionFuture<T>(exception e);
 
- * QFuture<T> createTimedFuture<T>(int time, T value, QObject* ctx);
- * QFuture<T> createTimedCanceledFuture<T>(int time, QObject* ctx);
- * QFuture<T> createTimedExceptionFuture<T>(int time, exception e, QObject* ctx);
+ * QFuture<T> createTimedFuture<T>(std::chrono::milliseconds time, T value, QObject* ctx);
+ * QFuture<T> createTimedCanceledFuture<T>(std::chrono::milliseconds time, QObject* ctx);
+ * QFuture<T> createTimedExceptionFuture<T>(std::chrono::milliseconds time, exception e, QObject* ctx);
 
  * getFutureState(QFuture<T>) -> [NotStarted, Running, Completed, CompletedWrong, Canceled, Exception]
 
@@ -572,9 +573,9 @@ template<typename T>
 
 
 template<typename T>
-[[nodiscard]] QFuture<T> createTimedFuture(int time, const T& value, QObject* ctx = nullptr)
+[[nodiscard]] QFuture<T> createTimedFuture(std::chrono::milliseconds time, const T& value, QObject* ctx = nullptr)
 {
-    if (!time)
+    if (time.count() <= 0)
         return createReadyFuture(value);
 
     Promise<T> promise(true);
@@ -594,11 +595,11 @@ template<typename T>
 }
 
 template<typename T>
-[[nodiscard]] QFuture<T> createTimedFutureRef(int time, const T& value, QObject* ctx)
+[[nodiscard]] QFuture<T> createTimedFutureRef(std::chrono::milliseconds time, const T& value, QObject* ctx)
 {
     assert(ctx);
 
-    if (!time)
+    if (time.count() <= 0)
         return createReadyFuture(value);
 
     Promise<T> promise(true);
@@ -616,9 +617,9 @@ template<typename T>
     return promise.future();
 }
 
-[[nodiscard]] static inline QFuture<void> createTimedFuture(int time, QObject* ctx = nullptr)
+[[nodiscard]] static inline QFuture<void> createTimedFuture(std::chrono::milliseconds time, QObject* ctx = nullptr)
 {
-    if (!time)
+    if (time.count() <= 0)
         return createReadyFuture();
 
     Promise<void> promise(true);
@@ -641,9 +642,9 @@ template<typename T>
 
 
 template<typename T>
-[[nodiscard]] QFuture<T> createTimedCanceledFuture(int time, QObject* ctx = nullptr)
+[[nodiscard]] QFuture<T> createTimedCanceledFuture(std::chrono::milliseconds time, QObject* ctx = nullptr)
 {
-    if (!time)
+    if (time.count() <= 0)
         return createCanceledFuture<T>();
 
     Promise<T> promise(true);
@@ -680,9 +681,9 @@ template<typename T,
 }
 
 template<typename T>
-[[nodiscard]] QFuture<T> createTimedExceptionFuture(int time, const std::exception_ptr& eptr, QObject* ctx = nullptr)
+[[nodiscard]] QFuture<T> createTimedExceptionFuture(std::chrono::milliseconds time, const std::exception_ptr& eptr, QObject* ctx = nullptr)
 {
-    if (!time)
+    if (time.count() <= 0)
         return createExceptionFuture<T>(eptr);
 
     Promise<T> promise(true);
@@ -707,7 +708,7 @@ template<typename T,
          typename Ex,
          typename = std::enable_if_t<std::is_base_of_v<std::exception, Ex>>
          >
-[[nodiscard]] QFuture<T> createTimedExceptionFuture(int time, const Ex& ex, QObject* ctx = nullptr)
+[[nodiscard]] QFuture<T> createTimedExceptionFuture(std::chrono::milliseconds time, const Ex& ex, QObject* ctx = nullptr)
 {
     return createTimedExceptionFuture<T>(time, std::make_exception_ptr(ex), ctx);
 }

--- a/headers/UtilsQt/OnProperty.h
+++ b/headers/UtilsQt/OnProperty.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include <cassert>
+#include <chrono>
 #include <QObject>
 #include <QTimer>
 #include <UtilsQt/invoke_method.h>
@@ -123,7 +124,7 @@ void onProperty(Object* object,
                 bool once,
                 QObject* context,
                 const Handler& handler,
-                int timeout = -1,
+                std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                 const Handler2& cancelHandler = UtilsQt::OnPropertyInternal::cancelStubHandler,
                 Qt::ConnectionType connectionType = Qt::AutoConnection)
 {
@@ -138,7 +139,7 @@ void onProperty(Object* object,
                 comparison,
                 cancelHandler);
 
-    if (timeout > 0) {
+    if (timeout.count() > 0) {
         auto timer = new QTimer();
         QObject::connect(timer, &QTimer::timeout, timer, &QTimer::deleteLater);
         watcher->addDependency(timer, UtilsQt::CancelReason::Timeout);
@@ -163,7 +164,7 @@ QFuture<void> onPropertyFuture(Object* object,
                                const T& expectedValue,
                                UtilsQt::Comparison comparison,
                                QObject* context,
-                               int timeout = -1,
+                               std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
                                Qt::ConnectionType connectionType = Qt::AutoConnection)
 {
     auto promise = UtilsQt::createPromise<void>(true);

--- a/tests/test/Test_Futures_0_Utils.cpp
+++ b/tests/test/Test_Futures_0_Utils.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QTimer>
@@ -14,6 +16,7 @@
 #include "internal/LifetimeTracker.h"
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -104,7 +107,7 @@ TEST(UtilsQt, Futures_Utils_createFinished)
 TEST(UtilsQt, Futures_Utils_Timed)
 {
     {
-        auto f = createTimedFuture(20);
+        auto f = createTimedFuture(20ms);
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -113,7 +116,7 @@ TEST(UtilsQt, Futures_Utils_Timed)
     }
 
     {
-        auto f = createTimedFuture(20, false);
+        auto f = createTimedFuture(20ms, false);
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -123,7 +126,7 @@ TEST(UtilsQt, Futures_Utils_Timed)
     }
 
     {
-        auto f = createTimedCanceledFuture<void>(20);
+        auto f = createTimedCanceledFuture<void>(20ms);
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -132,7 +135,7 @@ TEST(UtilsQt, Futures_Utils_Timed)
     }
 
     {
-        auto f = createTimedCanceledFuture<bool>(20);
+        auto f = createTimedCanceledFuture<bool>(20ms);
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -141,7 +144,7 @@ TEST(UtilsQt, Futures_Utils_Timed)
     }
 
     {
-        auto f = createTimedExceptionFuture<int>(20, std::make_exception_ptr(std::runtime_error("Test")));
+        auto f = createTimedExceptionFuture<int>(20ms, std::make_exception_ptr(std::runtime_error("Test")));
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -151,7 +154,7 @@ TEST(UtilsQt, Futures_Utils_Timed)
     }
 
     {
-        auto f = createTimedExceptionFuture<int>(20, std::runtime_error("Test"));
+        auto f = createTimedExceptionFuture<int>(20ms, std::runtime_error("Test"));
         ASSERT_FALSE(f.isFinished());
         ASSERT_FALSE(f.isCanceled());
         waitForFuture<QEventLoop>(f);
@@ -262,7 +265,7 @@ TEST(UtilsQt, Futures_Utils_Timed_onFinished)
         std::optional<bool> checkpoint1;
         std::optional<bool> checkpoint2;
         std::optional<bool> checkpoint3;
-        auto f = createTimedFuture(20);
+        auto f = createTimedFuture(20ms);
         onFinished(f, &ctx, [&checkpoint1](const std::optional<std::monostate>& optResult){ checkpoint1 = optResult.has_value(); });
         onResult(f, &ctx, [&checkpoint2](){ checkpoint2 = true; });
         onCanceled(f, &ctx, [&checkpoint3](){ checkpoint3 = true; });
@@ -277,7 +280,7 @@ TEST(UtilsQt, Futures_Utils_Timed_onFinished)
         std::optional<int> result;
         int result2 = -1;
         std::optional<bool> checkpoint3;
-        auto f = createTimedFuture(20, 170);
+        auto f = createTimedFuture(20ms, 170);
         onFinished(f, &ctx, [&result](const std::optional<int>& value){ result = value; });
         onResult(f, &ctx, [&result2](int value){ result2 = value; });
         onCanceled(f, &ctx, [&checkpoint3](){ checkpoint3 = true; });
@@ -293,7 +296,7 @@ TEST(UtilsQt, Futures_Utils_Timed_onFinished)
         std::optional<bool> checkpoint1;
         std::optional<bool> checkpoint2;
         std::optional<bool> checkpoint3;
-        auto f = createTimedCanceledFuture<void>(20);
+        auto f = createTimedCanceledFuture<void>(20ms);
         onFinished(f, &ctx, [&checkpoint1](const std::optional<std::monostate>& optResult){ checkpoint1 = optResult.has_value(); });
         onResult(f, &ctx, [&checkpoint2](){ checkpoint2 = true; });
         onCanceled(f, &ctx, [&checkpoint3](){ checkpoint3 = true; });
@@ -308,7 +311,7 @@ TEST(UtilsQt, Futures_Utils_Timed_onFinished)
         std::optional<int> result;
         int result2 = -1;
         std::optional<bool> checkpoint3;
-        auto f = createTimedCanceledFuture<int>(20);
+        auto f = createTimedCanceledFuture<int>(20ms);
         onFinished(f, &ctx, [&result](const std::optional<int>& value){ result = value; });
         onResult(f, &ctx, [&result2](int value){ result2 = value; });
         onCanceled(f, &ctx, [&checkpoint3](){ checkpoint3 = true; });
@@ -323,7 +326,7 @@ TEST(UtilsQt, Futures_Utils_Timed_onFinished)
 TEST(UtilsQt, Futures_Utils_context)
 {
     auto obj = new QObject();
-    auto f = createTimedFuture(20, 170, obj);
+    auto f = createTimedFuture(20ms, 170, obj);
 
     qApp->processEvents();
     qApp->processEvents();
@@ -342,7 +345,7 @@ TEST(UtilsQt, Futures_Utils_reference)
     {
         QObject obj;
         int value = 170;
-        auto f = createTimedFutureRef(20, value, &obj);
+        auto f = createTimedFutureRef(20ms, value, &obj);
         qApp->processEvents();
         qApp->processEvents();
         value = 210;
@@ -355,7 +358,7 @@ TEST(UtilsQt, Futures_Utils_reference)
     {
         auto obj = new QObject();
         int value = 170;
-        auto f = createTimedFutureRef(20, value, obj);
+        auto f = createTimedFutureRef(20ms, value, obj);
         qApp->processEvents();
         qApp->processEvents();
         value = 210;
@@ -378,7 +381,7 @@ TEST(UtilsQt, Futures_Utils_Lifetime)
     ASSERT_EQ(data.count(), 1);
 
     QObject context;
-    auto f = createTimedFuture(10, &context);
+    auto f = createTimedFuture(10ms, &context);
 
     ASSERT_EQ(data.count(), 1);
     onFinished(f, &context, [tracker](const auto&){ (void)tracker; });
@@ -532,7 +535,7 @@ TEST(UtilsQt, Futures_Utils_onCancelNotified)
 {
     QObject obj;
     int calls {};
-    auto f = UtilsQt::createTimedCanceledFuture<void>(10);
+    auto f = UtilsQt::createTimedCanceledFuture<void>(10ms);
 
     UtilsQt::onCancelNotified(f, &obj, [&]() {
         calls++;
@@ -545,7 +548,7 @@ TEST(UtilsQt, Futures_Utils_onCancelNotified)
         calls++;
     });
 
-    waitForFuture<QEventLoop>(createTimedFuture(10, 100));
+    waitForFuture<QEventLoop>(createTimedFuture(10ms, 100));
 
     qApp->processEvents();
     qApp->processEvents();
@@ -555,7 +558,7 @@ TEST(UtilsQt, Futures_Utils_onCancelNotified)
         calls++;
     });
 
-    f = UtilsQt::createTimedFuture<int>(10, 150);
+    f = UtilsQt::createTimedFuture<int>(10ms, 150);
     UtilsQt::onCancelNotified(f, &obj, [&]() {
         calls++;
     });
@@ -563,7 +566,7 @@ TEST(UtilsQt, Futures_Utils_onCancelNotified)
     waitForFuture<QEventLoop>(f);
     ASSERT_EQ(calls, 2);
 
-    f = UtilsQt::createTimedCanceledFuture<int>(10);
+    f = UtilsQt::createTimedCanceledFuture<int>(10ms);
     auto obj2 = std::make_unique<QObject>();
     UtilsQt::onCancelNotified(f, obj2.get(), [&]() {
         calls++;

--- a/tests/test/Test_Futures_1_Convert.cpp
+++ b/tests/test/Test_Futures_1_Convert.cpp
@@ -3,6 +3,7 @@
  * Contact:  ihor-drachuk-libs@pm.me  */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <UtilsQt/Futures/Converter.h>
 #include <UtilsQt/Futures/Utils.h>
 #include <QCoreApplication>
@@ -11,6 +12,7 @@
 #include "internal/LifetimeTracker.h"
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 
 TEST(UtilsQt, Futures_Convert)
@@ -89,7 +91,7 @@ TEST(UtilsQt, Futures_Convert)
 TEST(UtilsQt, Futures_Convert_Timed)
 {
     {
-        auto f = createTimedFuture(20, 170);
+        auto f = createTimedFuture(20ms, 170);
 
         int input = -1;
         const char* const result = "Test";
@@ -104,7 +106,7 @@ TEST(UtilsQt, Futures_Convert_Timed)
     }
 
     {
-        auto f = createTimedFuture(20, 170);
+        auto f = createTimedFuture(20ms, 170);
 
         int input = -1;
 
@@ -117,7 +119,7 @@ TEST(UtilsQt, Futures_Convert_Timed)
     }
 
     {
-        auto f = createTimedFuture(20);
+        auto f = createTimedFuture(20ms);
 
         bool ok = false;
         const char* const result = "Test";
@@ -132,7 +134,7 @@ TEST(UtilsQt, Futures_Convert_Timed)
     }
 
     {
-        auto f = createTimedFuture(20);
+        auto f = createTimedFuture(20ms);
 
         bool ok = false;
 
@@ -145,7 +147,7 @@ TEST(UtilsQt, Futures_Convert_Timed)
     }
 
     {
-        auto f = createTimedCanceledFuture<int>(20);
+        auto f = createTimedCanceledFuture<int>(20ms);
 
         bool ok = false;
 
@@ -158,7 +160,7 @@ TEST(UtilsQt, Futures_Convert_Timed)
     }
 
     {
-        auto f = createTimedCanceledFuture<void>(20);
+        auto f = createTimedCanceledFuture<void>(20ms);
 
         bool ok = false;
 
@@ -178,7 +180,7 @@ TEST(UtilsQt, Futures_Convert_Destruction)
         QFuture<int> resultFuture;
 
         {
-            auto f = createTimedFuture(100, 20);
+            auto f = createTimedFuture(100ms, 20);
 
             QObject ctx;
             resultFuture = convertFuture<int, int>(&ctx, f, [&](int value) -> std::optional<int> { ok = true; return value + 1; });
@@ -214,7 +216,7 @@ TEST(UtilsQt, Futures_Convert_Destruction)
 TEST(UtilsQt, Futures_Convert_StepByStep)
 {
     {
-        auto f = createTimedFuture(50, 1234);
+        auto f = createTimedFuture(50ms, 1234);
 
         auto conv = convertFuture<int, std::string>(nullptr, f, ConverterFlags::IgnoreNullContext, [&](int value) -> std::optional<std::string> { return std::to_string(value); });
 
@@ -253,21 +255,21 @@ TEST(UtilsQt, Futures_Convert_StepByStep)
         fi.reportStarted();
         ASSERT_TRUE(f.isStarted());
 
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_FALSE(conv.isCanceled());
         ASSERT_FALSE(conv.isFinished());
 
         fi.reportCanceled();
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_TRUE(conv.isCanceled());
         ASSERT_FALSE(conv.isFinished());
 
         fi.reportFinished();
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_TRUE(conv.isCanceled());
@@ -286,21 +288,21 @@ TEST(UtilsQt, Futures_Convert_StepByStep)
         ASSERT_FALSE(conv.isFinished());
 
         fi.reportStarted();
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_FALSE(conv.isCanceled());
         ASSERT_FALSE(conv.isFinished());
 
         fi.reportResult(1234);
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_FALSE(conv.isCanceled());
         ASSERT_FALSE(conv.isFinished());
 
         fi.reportFinished();
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_TRUE(conv.isStarted());
         ASSERT_FALSE(conv.isCanceled());
@@ -329,7 +331,7 @@ TEST(UtilsQt, Futures_Convert_CancelTarget)
         ASSERT_FALSE(conv.isFinished());
 
         conv.cancel();
-        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1));
+        waitForFuture<QEventLoop>(createTimedCanceledFuture<void>(1ms));
 
         ASSERT_FALSE(fi.isStarted());
         ASSERT_TRUE(fi.isCanceled());
@@ -383,7 +385,7 @@ TEST(UtilsQt, Futures_Convert_Lifetime)
     LifetimeTracker tracker;
 
     ASSERT_EQ(tracker.count(), 1);
-    auto f = convertFuture(nullptr, createTimedFuture(10), ConverterFlags::IgnoreNullContext, [tracker]() {
+    auto f = convertFuture(nullptr, createTimedFuture(10ms), ConverterFlags::IgnoreNullContext, [tracker]() {
         (void)tracker;
         return QString();
     });

--- a/tests/test/Test_Futures_2_Merge.cpp
+++ b/tests/test/Test_Futures_2_Merge.cpp
@@ -3,6 +3,7 @@
  * Contact:  ihor-drachuk-libs@pm.me  */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <UtilsQt/Futures/Utils.h>
 #include <UtilsQt/Futures/Merge.h>
 #include <QEventLoop>
@@ -10,6 +11,7 @@
 #include <string>
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 TEST(UtilsQt, Futures_Merge_TypesTest)
 {
@@ -73,7 +75,7 @@ TEST(UtilsQt, Futures_Merge)
     }
 
     {
-        auto f1 = createTimedFuture<int>(10, 123);
+        auto f1 = createTimedFuture<int>(10ms, 123);
         auto f2 = createCanceledFuture<int>();
         auto r1 = mergeFuturesAny(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
         auto r2 = mergeFuturesAll(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
@@ -87,8 +89,8 @@ TEST(UtilsQt, Futures_Merge)
     }
 
     {
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedCanceledFuture<int>(5);
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedCanceledFuture<int>(5ms);
         auto r1 = mergeFuturesAny(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
         auto r2 = mergeFuturesAll(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
 
@@ -100,8 +102,8 @@ TEST(UtilsQt, Futures_Merge)
     }
 
     {
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(5, "Test");
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(5ms, "Test");
         auto r = mergeFuturesAny(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
 
         waitForFuture<QEventLoop>(r);
@@ -116,8 +118,8 @@ TEST(UtilsQt, Futures_Merge)
 
 
     {
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(5, "Test");
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(5ms, "Test");
         auto r = mergeFuturesAll(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
 
         waitForFuture<QEventLoop>(r);
@@ -132,8 +134,8 @@ TEST(UtilsQt, Futures_Merge)
 
 
     { // std::tuple
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(5, "Test");
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(5ms, "Test");
         const auto futures = std::make_tuple(f1, f2);
         auto r = mergeFuturesAll(nullptr, MergeFlags::IgnoreNullContext, futures);
 
@@ -151,8 +153,8 @@ TEST(UtilsQt, Futures_Merge)
 TEST(UtilsQt, Futures_Merge_Container)
 {
     {
-        auto f1 = createTimedFuture<int>(10, 123);
-        auto f2 = createTimedFuture<int>(20, 124);
+        auto f1 = createTimedFuture<int>(10ms, 123);
+        auto f2 = createTimedFuture<int>(20ms, 124);
         auto r = mergeFuturesAll(nullptr, MergeFlags::IgnoreNullContext, std::vector{f1, f2});
 
         waitForFuture<QEventLoop>(r);
@@ -168,8 +170,8 @@ TEST(UtilsQt, Futures_Merge_Context)
 
     {
         QObject ctx;
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(100, "Test");
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(100ms, "Test");
         result = mergeFuturesAny(&ctx, f1, f2);
         ASSERT_FALSE(result.isCanceled());
     }
@@ -182,8 +184,8 @@ TEST(UtilsQt, Futures_Merge_TargetCancellation)
     {
         QFuture<void> result;
 
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(100, "Test");
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(100ms, "Test");
         result = mergeFuturesAny(nullptr, MergeFlags::IgnoreNullContext, f1, f2);
 
         ASSERT_FALSE(f1.isCanceled());
@@ -202,8 +204,8 @@ TEST(UtilsQt, Futures_Merge_TargetCancellation)
     {
         QFuture<void> result;
 
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<int>(100, 124);
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<int>(100ms, 124);
         result = mergeFuturesAny(nullptr, MergeFlags::IgnoreNullContext, std::vector{f1, f2});
 
         ASSERT_FALSE(f1.isCanceled());
@@ -224,10 +226,10 @@ TEST(UtilsQt, Futures_Merge_TargetCancellation)
 TEST(UtilsQt, Futures_Merge_TestResults)
 {
     {
-        auto f1 = createTimedFuture<int>(50, 123);
-        auto f2 = createTimedFuture<std::string>(100, "Test std::string");
-        auto f3 = createTimedCanceledFuture<float>(10);
-        auto f4 = createTimedFuture(50); // void
+        auto f1 = createTimedFuture<int>(50ms, 123);
+        auto f2 = createTimedFuture<std::string>(100ms, "Test std::string");
+        auto f3 = createTimedCanceledFuture<float>(10ms);
+        auto f4 = createTimedFuture(50ms); // void
         auto f5 = createReadyFuture(QString("Test QString"));
         auto futureResult = UtilsQt::mergeFuturesAll(nullptr,
                                                      MergeFlags::IgnoreSomeCancellation | MergeFlags::IgnoreNullContext,
@@ -249,8 +251,8 @@ TEST(UtilsQt, Futures_Merge_TestResults)
 
 TEST(UtilsQt, Futures_Merge_NonIgnoredNullContext)
 {
-    auto f1 = createTimedFuture<int>(50, 123);
-    auto f2 = createTimedFuture<std::string>(100, "Test std::string");
+    auto f1 = createTimedFuture<int>(50ms, 123);
+    auto f2 = createTimedFuture<std::string>(100ms, "Test std::string");
     auto futureResult = UtilsQt::mergeFuturesAll(nullptr, f1, f2);
 
     ASSERT_TRUE(futureResult.isCanceled());

--- a/tests/test/Test_Futures_4_CancellationChain.cpp
+++ b/tests/test/Test_Futures_4_CancellationChain.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 #include <UtilsQt/Futures/Utils.h>
 #include <UtilsQt/Futures/futureutils_sequential.h>
 #include <UtilsQt/Futures/Converter.h>
@@ -12,6 +14,7 @@
 #include <QEventLoop>
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 
 TEST(UtilsQt, Futures_CancellationChain_Convert)
@@ -22,7 +25,7 @@ TEST(UtilsQt, Futures_CancellationChain_Convert)
     });
 
     f.cancel();
-    waitForFuture<QEventLoop>(createTimedFuture(1));
+    waitForFuture<QEventLoop>(createTimedFuture(1ms));
 
     ASSERT_TRUE(promise.isCanceled());
 
@@ -44,7 +47,7 @@ TEST(UtilsQt, Futures_CancellationChain_Merge)
     auto f = UtilsQt::mergeFuturesAll(&ctx, futures);
 
     f.cancel();
-    waitForFuture<QEventLoop>(createTimedFuture(1));
+    waitForFuture<QEventLoop>(createTimedFuture(1ms));
 
     ASSERT_TRUE(p1.isCanceled());
     ASSERT_TRUE(p2.isCanceled());
@@ -65,7 +68,7 @@ TEST(UtilsQt, Futures_CancellationChain_RetryingFutureRR)
         nullptr,
         [&calls]() -> QFuture<int> {
             calls++;
-            return UtilsQt::createTimedFuture(27, 52);
+            return UtilsQt::createTimedFuture(27ms, 52);
         },
         [](const std::optional<int>& result) -> ValidatorDecision {
             return result.value_or(-1) == 48 ? ValidatorDecision::ResultIsValid : ValidatorDecision::NeedRetry;
@@ -87,7 +90,7 @@ TEST(UtilsQt, Futures_CancellationChain_RetryingFuture)
         nullptr,
         [&calls]() -> QFuture<int> {
             calls++;
-            return UtilsQt::createTimedFuture(27, 52);
+            return UtilsQt::createTimedFuture(27ms, 52);
         },
         [](const std::optional<int>& result) -> ValidatorDecision {
             return result.value_or(-1) == 48 ? ValidatorDecision::ResultIsValid : ValidatorDecision::NeedRetry;

--- a/tests/test/Test_Futures_5_SignalToFuture.cpp
+++ b/tests/test/Test_Futures_5_SignalToFuture.cpp
@@ -3,10 +3,13 @@
  * Contact:  ihor-drachuk-libs@pm.me  */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <UtilsQt/Futures/SignalToFuture.h>
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QString>
+
+using namespace std::chrono_literals;
 
 class Futures_SignalToFuture_TestClass : public QObject
 {
@@ -127,20 +130,20 @@ TEST(UtilsQt, Futures_SignalToFuture_Timeout)
     Class obj;
 
     // Timeout trigger
-    auto f = signalToFuture(&obj, &Class::someSignal1, nullptr, 100);
+    auto f = signalToFuture(&obj, &Class::someSignal1, nullptr, 100ms);
 
     qApp->processEvents();
     qApp->processEvents();
     ASSERT_FALSE(f.isFinished());
     ASSERT_FALSE(f.isCanceled());
 
-    waitForFuture<QEventLoop>(createTimedFuture(200));
+    waitForFuture<QEventLoop>(createTimedFuture(200ms));
 
     ASSERT_TRUE(f.isFinished());
     ASSERT_TRUE(f.isCanceled());
 
     // Timeout after signal
-    f = signalToFuture(&obj, &Class::someSignal1, nullptr, 100);
+    f = signalToFuture(&obj, &Class::someSignal1, nullptr, 100ms);
     qApp->processEvents();
     qApp->processEvents();
     ASSERT_FALSE(f.isFinished());
@@ -151,7 +154,7 @@ TEST(UtilsQt, Futures_SignalToFuture_Timeout)
     ASSERT_TRUE(f.isFinished());
     ASSERT_FALSE(f.isCanceled());
 
-    waitForFuture<QEventLoop>(createTimedFuture(200));
+    waitForFuture<QEventLoop>(createTimedFuture(200ms));
 
     ASSERT_TRUE(f.isFinished());
     ASSERT_FALSE(f.isCanceled());

--- a/tests/test/Test_Futures_6_Sequential.cpp
+++ b/tests/test/Test_Futures_6_Sequential.cpp
@@ -22,11 +22,12 @@
 
 using TestHelpers::waitForFlag;
 using TestHelpers::waitForCounter;
+using namespace std::chrono_literals;
 
 namespace {
 
 // Default work loop duration when thread needs to simulate ongoing work
-constexpr auto WorkLoopDuration = std::chrono::milliseconds(200);
+constexpr auto WorkLoopDuration = 200ms;
 
 struct OpStatistics
 {
@@ -163,8 +164,8 @@ TEST(UtilsQt, Futures_Sequential_DelayedResult)
 {
     QObject obj;
     auto f = UtilsQt::Sequential(&obj)
-                 .start([](){ return UtilsQt::createTimedFuture(10, 123); })
-                 .then([](const UtilsQt::AsyncResult<int>& r){ r.tryRethrow(); return UtilsQt::createTimedFuture(20, QString::number(r.value())); })
+                 .start([](){ return UtilsQt::createTimedFuture(10ms, 123); })
+                 .then([](const UtilsQt::AsyncResult<int>& r){ r.tryRethrow(); return UtilsQt::createTimedFuture(20ms, QString::number(r.value())); })
                  .execute();
 
     UtilsQt::waitForFuture<QEventLoop>(f);
@@ -404,8 +405,8 @@ TEST(UtilsQt, Futures_Sequential_ExternalCancellation)
 
     QObject obj;
     auto f = UtilsQt::Sequential(&obj)
-                 .start([&](const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; return UtilsQt::createTimedFuture(50, 15); })
-                 .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; r.tryRethrow(); return UtilsQt::createTimedFuture(50, QString::number(r.value())); })
+                 .start([&](const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; return UtilsQt::createTimedFuture(50ms, 15); })
+                 .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; r.tryRethrow(); return UtilsQt::createTimedFuture(50ms, QString::number(r.value())); })
                  .execute();
 
     f.cancel();
@@ -727,8 +728,8 @@ TEST(UtilsQt, Futures_Sequential_LoosingContext)
     int cancels {};
 
     auto f = UtilsQt::Sequential(obj.get())
-                 .start([&](const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; return UtilsQt::createTimedFuture(50, 15); })
-                 .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; r.tryRethrow(); return UtilsQt::createTimedFuture(50, QString::number(r.value())); })
+                 .start([&](const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; return UtilsQt::createTimedFuture(50ms, 15); })
+                 .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm){ calls++; if (sm.isCancelRequested()) cancels++; r.tryRethrow(); return UtilsQt::createTimedFuture(50ms, QString::number(r.value())); })
                  .execute();
 
     obj.reset();
@@ -744,8 +745,8 @@ TEST(UtilsQt, Futures_Sequential_LoosingContext)
 TEST(UtilsQt, Futures_Sequential_MissingContext)
 {
     auto f = UtilsQt::Sequential(nullptr)
-                 .start([](){ return UtilsQt::createTimedFuture(10, 123); })
-                 .then([](const UtilsQt::AsyncResult<int>& r){ r.tryRethrow(); return UtilsQt::createTimedFuture(20, QString::number(r.value())); })
+                 .start([](){ return UtilsQt::createTimedFuture(10ms, 123); })
+                 .then([](const UtilsQt::AsyncResult<int>& r){ r.tryRethrow(); return UtilsQt::createTimedFuture(20ms, QString::number(r.value())); })
                  .execute();
 
     UtilsQt::waitForFuture<QEventLoop>(f);
@@ -768,7 +769,7 @@ TEST(UtilsQt, Futures_Sequential_InternalCancellation)
                      if (sm.isCancelRequested())
                          cancels++;
 
-                     return UtilsQt::createTimedCanceledFuture<int>(50);
+                     return UtilsQt::createTimedCanceledFuture<int>(50ms);
                  })
                  .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm) {
                      calls++;
@@ -782,7 +783,7 @@ TEST(UtilsQt, Futures_Sequential_InternalCancellation)
 
                      } else {
                         r.tryRethrow();
-                         return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                         return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                      }
                  })
                  .execute();
@@ -822,7 +823,7 @@ TEST(UtilsQt, Futures_Sequential_Exception)
                          exceptionResults++;
 
                      r.tryRethrow();
-                     return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                     return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                  })
                  .execute();
 
@@ -857,7 +858,7 @@ TEST(UtilsQt, Futures_Sequential_Options_Cancellation)
                      if (sm.isCancelRequested())
                          cancels++;
 
-                     return UtilsQt::createTimedCanceledFuture<int>(50);
+                     return UtilsQt::createTimedCanceledFuture<int>(50ms);
                  })
                  .then([&](const UtilsQt::AsyncResult<int>& r, const UtilsQt::SequentialMediator& sm) {
                      calls++;
@@ -871,7 +872,7 @@ TEST(UtilsQt, Futures_Sequential_Options_Cancellation)
 
                      } else {
                          r.tryRethrow();
-                         return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                         return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                      }
                  })
                  .execute();
@@ -911,7 +912,7 @@ TEST(UtilsQt, Futures_Sequential_Options_Exception_1)
                          exceptionResults++;
 
                      r.tryRethrow();
-                     return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                     return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                  })
                  .execute();
 
@@ -959,7 +960,7 @@ TEST(UtilsQt, Futures_Sequential_Options_Exception_2)
                          exceptionResults++;
 
                      r.tryRethrow();
-                     return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                     return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                  })
                  .execute();
 
@@ -1009,7 +1010,7 @@ TEST(UtilsQt, Futures_Sequential_Options_Exception_3)
                      r.tryRethrow();
 
                      throw MyException();
-                     //return UtilsQt::createTimedFuture(50, QString::number(r.value()));
+                     //return UtilsQt::createTimedFuture(50ms, QString::number(r.value()));
                  })
                  .execute();
 

--- a/tests/test/Test_Futures_7_Broker.cpp
+++ b/tests/test/Test_Futures_7_Broker.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+
 #include <UtilsQt/Futures/Broker.h>
 #include <UtilsQt/Futures/Utils.h>
 #include <QCoreApplication>
@@ -15,7 +17,7 @@ using namespace UtilsQt;
 namespace {
 
 // Duration for "running" futures - long enough to test state transitions
-constexpr unsigned FutureDuration = 200;
+constexpr auto FutureDuration = std::chrono::milliseconds(200);
 
 class MyException : public std::exception
 {
@@ -77,7 +79,7 @@ TEST(UtilsQt, Futures_Broker_ConstructorWithFuture)
 
     // Test constructor with running future
     {
-        Broker<int> broker(createTimedFuture(FutureDuration, 123));
+        Broker<int> broker(createTimedFuture(FutureDuration.count(), 123));
         ASSERT_TRUE(broker.hasRunningFuture());
 
         auto destFuture = broker.future();
@@ -205,7 +207,7 @@ TEST(UtilsQt, Futures_Broker_DelayedBinding)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedFuture(FutureDuration, 123));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 123));
 
     ASSERT_TRUE(broker.hasRunningFuture());
 
@@ -249,7 +251,7 @@ TEST(UtilsQt, Futures_Broker_ReplaceRunningFuture)
     Broker<int> broker;
 
     // Bind a long-running future
-    auto sourceFuture1 = createTimedFuture(FutureDuration, 42);
+    auto sourceFuture1 = createTimedFuture(FutureDuration.count(), 42);
     broker.rebind(sourceFuture1);
 
     ASSERT_TRUE(broker.hasRunningFuture());
@@ -276,7 +278,7 @@ TEST(UtilsQt, Futures_Broker_CancellationFromSource)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedCanceledFuture<int>(FutureDuration));
+    broker.rebind(createTimedCanceledFuture<int>(FutureDuration.count()));
 
     auto destFuture = broker.future();
     waitForFuture<QEventLoop>(destFuture);
@@ -290,7 +292,7 @@ TEST(UtilsQt, Futures_Broker_CancellationFromDestination)
 {
     Broker<int> broker;
 
-    auto sourceFuture = createTimedFuture(FutureDuration, 42);
+    auto sourceFuture = createTimedFuture(FutureDuration.count(), 42);
     broker.rebind(sourceFuture);
 
     auto destFuture = broker.future();
@@ -325,7 +327,7 @@ TEST(UtilsQt, Futures_Broker_ExceptionHandling)
     ASSERT_THROW(destFuture.result(), MyException);
 
     // Test binding a new future after exception
-    broker.rebind(createTimedFuture(FutureDuration, 123));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 123));
     auto newDestFuture = broker.future();
     waitForFuture<QEventLoop>(newDestFuture);
 
@@ -338,7 +340,7 @@ TEST(UtilsQt, Futures_Broker_TimedExceptionHandling)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedExceptionFuture<int>(FutureDuration, MyException()));
+    broker.rebind(createTimedExceptionFuture<int>(FutureDuration.count(), MyException()));
 
     auto destFuture = broker.future();
     waitForFuture<QEventLoop>(destFuture);
@@ -349,7 +351,7 @@ TEST(UtilsQt, Futures_Broker_TimedExceptionHandling)
     ASSERT_THROW(destFuture.result(), MyException);
 
     // Test binding a new future after timed exception
-    broker.rebind(createTimedFuture(FutureDuration, 456));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 456));
     auto newDestFuture = broker.future();
     waitForFuture<QEventLoop>(newDestFuture);
 
@@ -391,16 +393,16 @@ TEST(UtilsQt, Futures_Broker_TimedMultipleReplacements)
     Broker<QString> broker;
 
     // First timed future
-    broker.rebind(createTimedFuture(FutureDuration, QString("First")));
+    broker.rebind(createTimedFuture(FutureDuration.count(), QString("First")));
     auto future1 = broker.future();
     ASSERT_FALSE(future1.isFinished());
 
     // Second timed future (replaces first)
-    broker.rebind(createTimedFuture(FutureDuration, QString("Second")));
+    broker.rebind(createTimedFuture(FutureDuration.count(), QString("Second")));
     auto future2 = broker.future();
 
     // Third timed future (replaces second)
-    broker.rebind(createTimedFuture(FutureDuration, QString("Third")));
+    broker.rebind(createTimedFuture(FutureDuration.count(), QString("Third")));
     auto future3 = broker.future();
 
     // Wait for completion
@@ -430,7 +432,7 @@ TEST(UtilsQt, Futures_Broker_StateTransitions)
     ASSERT_FALSE(broker.hasRunningFuture());
 
     // Bind running future
-    broker.rebind(createTimedFuture(FutureDuration, 42));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
     ASSERT_TRUE(broker.hasRunningFuture());
 
     // Wait for completion
@@ -454,7 +456,7 @@ TEST(UtilsQt, Futures_Broker_CancellationDuringReplacement)
     Broker<int> broker;
 
     // Start with a long-running future
-    broker.rebind(createTimedFuture(FutureDuration, 42));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
     auto destFuture1 = broker.future();
 
     // Cancel the destination
@@ -519,7 +521,7 @@ TEST(UtilsQt, Futures_Broker_ContextDestruction)
 {
     auto broker = std::make_unique<Broker<int>>();
 
-    broker->rebind(createTimedFuture(FutureDuration, 42));
+    broker->rebind(createTimedFuture(FutureDuration.count(), 42));
     auto destFuture = broker->future();
 
     // Destroy context
@@ -543,14 +545,14 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_FALSE(future1.isCanceled());
 
     // Replace with timed void future
-    broker.rebind(createTimedFuture(FutureDuration));
+    broker.rebind(createTimedFuture(FutureDuration.count()));
     auto future2 = broker.future();
     waitForFuture<QEventLoop>(future2);
     ASSERT_TRUE(future2.isFinished());
     ASSERT_FALSE(future2.isCanceled());
 
     // Test replacement of unfinished future
-    auto sourceFuture = createTimedFuture(FutureDuration);
+    auto sourceFuture = createTimedFuture(FutureDuration.count());
     broker.rebind(sourceFuture);
     auto future3 = broker.future();
 
@@ -572,7 +574,7 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_FALSE(future4.isCanceled());
 
     // Replace with canceled void future
-    broker.rebind(createTimedCanceledFuture<void>(FutureDuration));
+    broker.rebind(createTimedCanceledFuture<void>(FutureDuration.count()));
     auto future5 = broker.future();
     waitForFuture<QEventLoop>(future5);
     ASSERT_TRUE(future5.isFinished());
@@ -588,7 +590,7 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_THROW(future6.waitForFinished(), MyException);
 
     // Test timed exception handling
-    broker.rebind(createTimedExceptionFuture<void>(FutureDuration, MyException()));
+    broker.rebind(createTimedExceptionFuture<void>(FutureDuration.count(), MyException()));
     auto future7 = broker.future();
     waitForFuture<QEventLoop>(future7);
     ASSERT_TRUE(future7.isFinished());
@@ -635,7 +637,7 @@ TEST(UtilsQt, Futures_Broker_Reset_DuringRunning)
     Broker<int> broker;
 
     // Bind a long-running future
-    auto sourceFuture = createTimedFuture(FutureDuration, 123);
+    auto sourceFuture = createTimedFuture(FutureDuration.count(), 123);
     broker.rebind(sourceFuture);
     ASSERT_TRUE(broker.hasRunningFuture());
 
@@ -664,7 +666,7 @@ TEST(UtilsQt, Futures_Broker_Reset_VoidFuture)
     Broker<void> broker;
 
     // Bind a void future
-    broker.rebind(createTimedFuture(FutureDuration));
+    broker.rebind(createTimedFuture(FutureDuration.count()));
     ASSERT_TRUE(broker.hasRunningFuture());
 
     auto destFuture1 = broker.future();
@@ -755,7 +757,7 @@ TEST(UtilsQt, Futures_Broker_Reset_AfterCancellation)
     Broker<int> broker;
 
     // Bind and cancel
-    broker.rebind(createTimedFuture(FutureDuration, 42));
+    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
     auto destFuture1 = broker.future();
     destFuture1.cancel();
 

--- a/tests/test/Test_Futures_7_Broker.cpp
+++ b/tests/test/Test_Futures_7_Broker.cpp
@@ -13,11 +13,12 @@
 #include <QString>
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 namespace {
 
 // Duration for "running" futures - long enough to test state transitions
-constexpr auto FutureDuration = std::chrono::milliseconds(200);
+constexpr auto FutureDuration = 200ms;
 
 class MyException : public std::exception
 {
@@ -79,7 +80,7 @@ TEST(UtilsQt, Futures_Broker_ConstructorWithFuture)
 
     // Test constructor with running future
     {
-        Broker<int> broker(createTimedFuture(FutureDuration.count(), 123));
+        Broker<int> broker(createTimedFuture(FutureDuration, 123));
         ASSERT_TRUE(broker.hasRunningFuture());
 
         auto destFuture = broker.future();
@@ -207,7 +208,7 @@ TEST(UtilsQt, Futures_Broker_DelayedBinding)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedFuture(FutureDuration.count(), 123));
+    broker.rebind(createTimedFuture(FutureDuration, 123));
 
     ASSERT_TRUE(broker.hasRunningFuture());
 
@@ -251,7 +252,7 @@ TEST(UtilsQt, Futures_Broker_ReplaceRunningFuture)
     Broker<int> broker;
 
     // Bind a long-running future
-    auto sourceFuture1 = createTimedFuture(FutureDuration.count(), 42);
+    auto sourceFuture1 = createTimedFuture(FutureDuration, 42);
     broker.rebind(sourceFuture1);
 
     ASSERT_TRUE(broker.hasRunningFuture());
@@ -278,7 +279,7 @@ TEST(UtilsQt, Futures_Broker_CancellationFromSource)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedCanceledFuture<int>(FutureDuration.count()));
+    broker.rebind(createTimedCanceledFuture<int>(FutureDuration));
 
     auto destFuture = broker.future();
     waitForFuture<QEventLoop>(destFuture);
@@ -292,7 +293,7 @@ TEST(UtilsQt, Futures_Broker_CancellationFromDestination)
 {
     Broker<int> broker;
 
-    auto sourceFuture = createTimedFuture(FutureDuration.count(), 42);
+    auto sourceFuture = createTimedFuture(FutureDuration, 42);
     broker.rebind(sourceFuture);
 
     auto destFuture = broker.future();
@@ -327,7 +328,7 @@ TEST(UtilsQt, Futures_Broker_ExceptionHandling)
     ASSERT_THROW(destFuture.result(), MyException);
 
     // Test binding a new future after exception
-    broker.rebind(createTimedFuture(FutureDuration.count(), 123));
+    broker.rebind(createTimedFuture(FutureDuration, 123));
     auto newDestFuture = broker.future();
     waitForFuture<QEventLoop>(newDestFuture);
 
@@ -340,7 +341,7 @@ TEST(UtilsQt, Futures_Broker_TimedExceptionHandling)
 {
     Broker<int> broker;
 
-    broker.rebind(createTimedExceptionFuture<int>(FutureDuration.count(), MyException()));
+    broker.rebind(createTimedExceptionFuture<int>(FutureDuration, MyException()));
 
     auto destFuture = broker.future();
     waitForFuture<QEventLoop>(destFuture);
@@ -351,7 +352,7 @@ TEST(UtilsQt, Futures_Broker_TimedExceptionHandling)
     ASSERT_THROW(destFuture.result(), MyException);
 
     // Test binding a new future after timed exception
-    broker.rebind(createTimedFuture(FutureDuration.count(), 456));
+    broker.rebind(createTimedFuture(FutureDuration, 456));
     auto newDestFuture = broker.future();
     waitForFuture<QEventLoop>(newDestFuture);
 
@@ -393,16 +394,16 @@ TEST(UtilsQt, Futures_Broker_TimedMultipleReplacements)
     Broker<QString> broker;
 
     // First timed future
-    broker.rebind(createTimedFuture(FutureDuration.count(), QString("First")));
+    broker.rebind(createTimedFuture(FutureDuration, QString("First")));
     auto future1 = broker.future();
     ASSERT_FALSE(future1.isFinished());
 
     // Second timed future (replaces first)
-    broker.rebind(createTimedFuture(FutureDuration.count(), QString("Second")));
+    broker.rebind(createTimedFuture(FutureDuration, QString("Second")));
     auto future2 = broker.future();
 
     // Third timed future (replaces second)
-    broker.rebind(createTimedFuture(FutureDuration.count(), QString("Third")));
+    broker.rebind(createTimedFuture(FutureDuration, QString("Third")));
     auto future3 = broker.future();
 
     // Wait for completion
@@ -432,7 +433,7 @@ TEST(UtilsQt, Futures_Broker_StateTransitions)
     ASSERT_FALSE(broker.hasRunningFuture());
 
     // Bind running future
-    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
+    broker.rebind(createTimedFuture(FutureDuration, 42));
     ASSERT_TRUE(broker.hasRunningFuture());
 
     // Wait for completion
@@ -442,7 +443,7 @@ TEST(UtilsQt, Futures_Broker_StateTransitions)
     ASSERT_FALSE(broker.hasRunningFuture()); // Finished but still has future
 
     // Replace finished future
-    broker.rebind(createTimedFuture(50, 84));
+    broker.rebind(createTimedFuture(50ms, 84));
     ASSERT_TRUE(broker.hasRunningFuture()); // New running future
 
     auto future2 = broker.future();
@@ -456,7 +457,7 @@ TEST(UtilsQt, Futures_Broker_CancellationDuringReplacement)
     Broker<int> broker;
 
     // Start with a long-running future
-    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
+    broker.rebind(createTimedFuture(FutureDuration, 42));
     auto destFuture1 = broker.future();
 
     // Cancel the destination
@@ -521,7 +522,7 @@ TEST(UtilsQt, Futures_Broker_ContextDestruction)
 {
     auto broker = std::make_unique<Broker<int>>();
 
-    broker->rebind(createTimedFuture(FutureDuration.count(), 42));
+    broker->rebind(createTimedFuture(FutureDuration, 42));
     auto destFuture = broker->future();
 
     // Destroy context
@@ -545,14 +546,14 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_FALSE(future1.isCanceled());
 
     // Replace with timed void future
-    broker.rebind(createTimedFuture(FutureDuration.count()));
+    broker.rebind(createTimedFuture(FutureDuration));
     auto future2 = broker.future();
     waitForFuture<QEventLoop>(future2);
     ASSERT_TRUE(future2.isFinished());
     ASSERT_FALSE(future2.isCanceled());
 
     // Test replacement of unfinished future
-    auto sourceFuture = createTimedFuture(FutureDuration.count());
+    auto sourceFuture = createTimedFuture(FutureDuration);
     broker.rebind(sourceFuture);
     auto future3 = broker.future();
 
@@ -561,7 +562,7 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_FALSE(sourceFuture.isFinished());
 
     // Replace before completion
-    broker.rebind(createTimedFuture(50));
+    broker.rebind(createTimedFuture(50ms));
     auto future4 = broker.future();
     ASSERT_TRUE(sameOperation(future4, future3));
     qApp->processEvents();
@@ -574,7 +575,7 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_FALSE(future4.isCanceled());
 
     // Replace with canceled void future
-    broker.rebind(createTimedCanceledFuture<void>(FutureDuration.count()));
+    broker.rebind(createTimedCanceledFuture<void>(FutureDuration));
     auto future5 = broker.future();
     waitForFuture<QEventLoop>(future5);
     ASSERT_TRUE(future5.isFinished());
@@ -590,7 +591,7 @@ TEST(UtilsQt, Futures_Broker_VoidFutureOperations)
     ASSERT_THROW(future6.waitForFinished(), MyException);
 
     // Test timed exception handling
-    broker.rebind(createTimedExceptionFuture<void>(FutureDuration.count(), MyException()));
+    broker.rebind(createTimedExceptionFuture<void>(FutureDuration, MyException()));
     auto future7 = broker.future();
     waitForFuture<QEventLoop>(future7);
     ASSERT_TRUE(future7.isFinished());
@@ -637,7 +638,7 @@ TEST(UtilsQt, Futures_Broker_Reset_DuringRunning)
     Broker<int> broker;
 
     // Bind a long-running future
-    auto sourceFuture = createTimedFuture(FutureDuration.count(), 123);
+    auto sourceFuture = createTimedFuture(FutureDuration, 123);
     broker.rebind(sourceFuture);
     ASSERT_TRUE(broker.hasRunningFuture());
 
@@ -666,7 +667,7 @@ TEST(UtilsQt, Futures_Broker_Reset_VoidFuture)
     Broker<void> broker;
 
     // Bind a void future
-    broker.rebind(createTimedFuture(FutureDuration.count()));
+    broker.rebind(createTimedFuture(FutureDuration));
     ASSERT_TRUE(broker.hasRunningFuture());
 
     auto destFuture1 = broker.future();
@@ -757,7 +758,7 @@ TEST(UtilsQt, Futures_Broker_Reset_AfterCancellation)
     Broker<int> broker;
 
     // Bind and cancel
-    broker.rebind(createTimedFuture(FutureDuration.count(), 42));
+    broker.rebind(createTimedFuture(FutureDuration, 42));
     auto destFuture1 = broker.future();
     destFuture1.cancel();
 

--- a/tests/test/internal/TestWaitHelpers.h
+++ b/tests/test/internal/TestWaitHelpers.h
@@ -14,11 +14,13 @@
 
 namespace TestHelpers {
 
+using namespace std::chrono_literals;
+
 // Maximum timeout for any single wait operation (generous to handle slow CI)
-constexpr auto MaxWaitTimeout = std::chrono::milliseconds(10000);
+constexpr auto MaxWaitTimeout = 10s;
 
 // Poll interval during wait loops
-constexpr auto WaitPollInterval = std::chrono::milliseconds(10);
+constexpr auto WaitPollInterval = 10ms;
 
 // Generic wait helper: waits until predicate returns true or timeout expires.
 // Processes Qt events during wait to allow signal/slot delivery.
@@ -29,8 +31,7 @@ bool waitUntil(Predicate&& pred, std::chrono::milliseconds timeout = MaxWaitTime
     const auto deadline = Clock::now() + timeout;
     while (!pred() && Clock::now() < deadline) {
         // Process Qt events to allow signal/slot delivery
-        UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(
-            static_cast<int>(WaitPollInterval.count())));
+        UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(WaitPollInterval));
     }
     return pred();
 }

--- a/tests/test/test01c_futureUtilsSeq.cpp
+++ b/tests/test/test01c_futureUtilsSeq.cpp
@@ -6,11 +6,13 @@
 
 #define FUTUREUTILS_NO_DEPRECATED
 
+#include <chrono>
 #include <string>
 #include <QEventLoop>
 #include <UtilsQt/Futures/futureutils_sequential.h>
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 
 TEST(UtilsQt, FutureUtilsSeqTest_basic)
@@ -20,9 +22,9 @@ TEST(UtilsQt, FutureUtilsSeqTest_basic)
     bool errorFlag = false;
 
     auto done =
-    connectFutureSeq(createTimedFuture(20, 170), &ctx)
+    connectFutureSeq(createTimedFuture(20ms, 170), &ctx)
          .then([](const std::optional<int>& value) -> QFuture<std::string> { return createReadyFuture(std::to_string(value.value() + 1)); })
-         .then([](const std::optional<std::string>& value) -> QFuture<float> { return createTimedFuture(40, (float)std::stoi(value.value())); })
+         .then([](const std::optional<std::string>& value) -> QFuture<float> { return createTimedFuture(40ms, (float)std::stoi(value.value())); })
          .then([&result](const std::optional<float>& value) { result = value.value(); })
          .onError([&errorFlag](std::exception_ptr) { errorFlag = true; })
          .readyPromise();
@@ -48,7 +50,7 @@ TEST(UtilsQt, FutureUtilsSeqTest_cancel_getFuture)
     QFuture<float> result3;
 
     auto done =
-    connectFutureSeq(createTimedFuture(20, 170), &ctx)
+    connectFutureSeq(createTimedFuture(20ms, 170), &ctx)
          .getFuture(result1)
          .then([&](const std::optional<int>& value) -> QFuture<std::string> { visited[0] = true; valueProvided[0] = value.has_value(); return createReadyFuture(std::to_string(value.value() + 1)); })
          .getFuture(result2)
@@ -100,7 +102,7 @@ TEST(UtilsQt, FutureUtilsSeqTest_exception)
     bool errorFlag = false;
 
     auto done =
-    connectFutureSeq(createTimedFuture(20, 170), &ctx)
+    connectFutureSeq(createTimedFuture(20ms, 170), &ctx)
          .then([](const std::optional<int>& value) -> QFuture<std::string> { return createReadyFuture(std::to_string(value.value() + 1)); })
          .then([](const std::optional<std::string>& /*value*/) -> QFuture<float> { throw 1; return {}; })
          .then([&result](const std::optional<float>& value) { result = value.value(); })
@@ -122,9 +124,9 @@ TEST(UtilsQt, FutureUtilsSeqTest_context)
     bool value3Called = false;
 
     auto done =
-    connectFutureSeq(createTimedFuture(20, 170), ctx)
+    connectFutureSeq(createTimedFuture(20ms, 170), ctx)
          .then([](const std::optional<int>& value) -> QFuture<std::string> { return createReadyFuture(std::to_string(value.value() + 1)); })
-         .then([&ctx](const std::optional<std::string>& value) -> QFuture<float> { ctx->deleteLater(); return createTimedFuture(40, (float)std::stoi(value.value())); })
+         .then([&ctx](const std::optional<std::string>& value) -> QFuture<float> { ctx->deleteLater(); return createTimedFuture(40ms, (float)std::stoi(value.value())); })
          .then([&](const std::optional<float>& value) { value3Called = true; result = value.value(); })
          .onError([&errorFlag](std::exception_ptr) { errorFlag = true; })
          .readyPromise();

--- a/tests/test/test03_onProperty.cpp
+++ b/tests/test/test03_onProperty.cpp
@@ -3,6 +3,7 @@
  * Contact:  ihor-drachuk-libs@pm.me  */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <UtilsQt/OnProperty.h>
 #include <UtilsQt/Futures/Utils.h>
 #include <QTimer>
@@ -10,6 +11,7 @@
 #include <QEventLoop>
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 class TestObject : public QObject
 {
@@ -65,7 +67,7 @@ TEST(UtilsQt, onProperty_initial)
         {
             triggeredCount++;
         },
-        100,
+        100ms,
         [&](auto){ cancelledCount++; });
 
         ASSERT_EQ(triggeredCount, 1);
@@ -118,7 +120,7 @@ TEST(UtilsQt, onProperty_once)
             triggeredCount++;
             loop.quit();
         },
-        700,
+        700ms,
         [&](auto){ cancelledCount++; });
         loop.exec();
 
@@ -133,7 +135,7 @@ TEST(UtilsQt, onProperty_once)
         ASSERT_LE(elapsed, 2000) << "Triggered too late";
 
         // Wait a bit more and verify no additional triggers
-        waitForFuture<QEventLoop>(createTimedFuture(200));
+        waitForFuture<QEventLoop>(createTimedFuture(200ms));
         ASSERT_EQ(triggeredCount, 1);
         ASSERT_EQ(cancelledCount, 0);
     }
@@ -163,7 +165,7 @@ TEST(UtilsQt, onProperty_once)
         ASSERT_LE(elapsed, 2000) << "Triggered too late";
 
         // Wait a bit more and verify no additional triggers
-        waitForFuture<QEventLoop>(createTimedFuture(200));
+        waitForFuture<QEventLoop>(createTimedFuture(200ms));
         ASSERT_EQ(triggeredCount, 1);
     }
 }
@@ -181,7 +183,7 @@ TEST(UtilsQt, onProperty_multiple)
 
     // Wait for multiple triggers (binary mode: toggles 0->1->0->1...)
     // Timer fires every 100ms, so in ~800ms we should see several triggers
-    waitForFuture<QEventLoop>(createTimedFuture(800));
+    waitForFuture<QEventLoop>(createTimedFuture(800ms));
 
     // Should have triggered multiple times (at least 3 times in 800ms with 100ms interval)
     ASSERT_GE(triggeredCount, 2) << "Too few triggers";
@@ -191,7 +193,7 @@ TEST(UtilsQt, onProperty_multiple)
     delete context; context = nullptr;
 
     // After context destruction, no more triggers
-    waitForFuture<QEventLoop>(createTimedFuture(400));
+    waitForFuture<QEventLoop>(createTimedFuture(400ms));
     ASSERT_EQ(savedCount, triggeredCount);
 }
 
@@ -215,14 +217,14 @@ TEST(UtilsQt, onProperty_cancelled)
             triggeredCount++;
             elapsed = elapsedTimer.elapsed();
         },
-        150,
+        150ms,
         [&](UtilsQt::CancelReason value){
             reason = value;
             elapsed = elapsedTimer.elapsed();
         }
         );
 
-        waitForFuture<QEventLoop>(createTimedFuture(500));
+        waitForFuture<QEventLoop>(createTimedFuture(500ms));
 
         if (stopTimer) {
             ASSERT_EQ(triggeredCount, 0);
@@ -268,7 +270,7 @@ TEST(UtilsQt, onProperty_future)
         QObject context;
         TestObject testObject;
 
-        auto f = onPropertyFuture(&testObject, &TestObject::counter, &TestObject::counterChanged, 3, UtilsQt::Comparison::Equal, &context, 20);
+        auto f = onPropertyFuture(&testObject, &TestObject::counter, &TestObject::counterChanged, 3, UtilsQt::Comparison::Equal, &context, 20ms);
 
         ASSERT_FALSE(f.isFinished());
         QEventLoop loop;

--- a/tests/test/test07_FileWatcher.cpp
+++ b/tests/test/test07_FileWatcher.cpp
@@ -18,17 +18,17 @@
 #include "internal/TestWaitHelpers.h"
 
 using namespace UtilsQt;
+using namespace std::chrono_literals;
 
 namespace {
 
 // Maximum time to wait for file system events (generous for slow CI/macOS)
-constexpr auto FileChangeTimeout = std::chrono::milliseconds(5000);
+constexpr auto FileChangeTimeout = 5s;
 
 // Helper to wait for FileWatcher::fileChanged signal with timeout
 bool waitForFileChange(FileWatcher& fw, std::chrono::milliseconds timeout = FileChangeTimeout)
 {
-    auto f = signalToFuture(&fw, &FileWatcher::fileChanged, nullptr,
-                            static_cast<int>(timeout.count()));
+    auto f = signalToFuture(&fw, &FileWatcher::fileChanged, nullptr, timeout);
     waitForFuture<QEventLoop>(f);
     return !f.isCanceled();
 }

--- a/tests/test/test07_FileWatcher.cpp
+++ b/tests/test/test07_FileWatcher.cpp
@@ -3,6 +3,7 @@
  * Contact:  ihor-drachuk-libs@pm.me  */
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <QEventLoop>
 #include <QStandardPaths>
 #include <QFile>
@@ -14,17 +15,20 @@
 #include <UtilsQt/Futures/SignalToFuture.h>
 #include <UtilsQt/Qml-Cpp/FileWatcher.h>
 
+#include "internal/TestWaitHelpers.h"
+
 using namespace UtilsQt;
 
 namespace {
 
 // Maximum time to wait for file system events (generous for slow CI/macOS)
-constexpr int FileChangeTimeout = 5000;
+constexpr auto FileChangeTimeout = std::chrono::milliseconds(5000);
 
 // Helper to wait for FileWatcher::fileChanged signal with timeout
-bool waitForFileChange(FileWatcher& fw, int timeoutMs = FileChangeTimeout)
+bool waitForFileChange(FileWatcher& fw, std::chrono::milliseconds timeout = FileChangeTimeout)
 {
-    auto f = signalToFuture(&fw, &FileWatcher::fileChanged, nullptr, timeoutMs);
+    auto f = signalToFuture(&fw, &FileWatcher::fileChanged, nullptr,
+                            static_cast<int>(timeout.count()));
     waitForFuture<QEventLoop>(f);
     return !f.isCanceled();
 }

--- a/tests/test/test13_SteadyTimer.cpp
+++ b/tests/test/test13_SteadyTimer.cpp
@@ -11,6 +11,8 @@
 
 #include "internal/TestWaitHelpers.h"
 
+using namespace std::chrono_literals;
+
 namespace {
 
 using Clock = std::chrono::steady_clock;
@@ -43,8 +45,7 @@ struct TimerTestHelper {
 
     // Wait for signal with timeout, returns true if signal received
     bool waitForTimeout(std::chrono::milliseconds timeout = TestHelpers::MaxWaitTimeout) {
-        auto f = UtilsQt::signalToFuture(&timer, &SteadyTimer::timeout, nullptr,
-                                         static_cast<int>(timeout.count()));
+        auto f = UtilsQt::signalToFuture(&timer, &SteadyTimer::timeout, nullptr, timeout);
         UtilsQt::waitForFuture<QEventLoop>(f);
         return !f.isCanceled();
     }
@@ -136,7 +137,7 @@ TEST(UtilsQt, SteadyTimer_StartStop)
     helper.start(200);
 
     // Wait a bit, but not long enough for timer
-    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(50));
+    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(50ms));
     ASSERT_EQ(helper.triggerCount, 0);
     ASSERT_TRUE(helper.timer.active());
 
@@ -146,7 +147,7 @@ TEST(UtilsQt, SteadyTimer_StartStop)
     ASSERT_FALSE(helper.timer.active());
 
     // Wait more - timer should NOT fire since it's stopped
-    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(300));
+    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(300ms));
     ASSERT_EQ(helper.triggerCount, 0);
 }
 
@@ -170,14 +171,14 @@ TEST(UtilsQt, SteadyTimer_Repeat)
     helper.timer.stop();
     int countAtStop = helper.triggerCount;
 
-    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(250));
+    UtilsQt::waitForFuture<QEventLoop>(UtilsQt::createTimedFuture(250ms));
     ASSERT_EQ(helper.triggerCount, countAtStop) << "Timer triggered after stop";
 }
 
 TEST(UtilsQt, SteadyTimer_ZeroInterval)
 {
     TimerTestHelper helper;
-    auto f = UtilsQt::signalToFuture(&helper.timer, &SteadyTimer::timeout, nullptr, 200);
+    auto f = UtilsQt::signalToFuture(&helper.timer, &SteadyTimer::timeout, nullptr, 200ms);
     helper.timer.start(0);
 
     ASSERT_FALSE(helper.timer.active());  // Should immediately become inactive


### PR DESCRIPTION
## Summary

All timed future functions now use std::chrono::milliseconds instead of int.

## API changes

- createTimedFuture(ms, value, ctx)
- createTimedCanceledFuture<T>(ms, ctx)
- createTimedExceptionFuture<T>(ms, exception, ctx)
- onProperty(..., timeout_ms, ...)
- signalToFuture - removed deprecated overload with unsigned long

## Benefits

- Type-safe duration parameters
- Self-documenting code with chrono literals (100ms, 2s)
- Native QTimer::start(chrono) support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a breaking API change across multiple public helper functions (timed futures, `onProperty`, `signalToFuture`), so downstream call sites must be updated and subtle unit mismatches are possible.
> 
> **Overview**
> **Type-safe timing API migration.** Replaces `int`/`unsigned long` millisecond parameters with `std::chrono::milliseconds` for timed future helpers (`createTimedFuture`, `createTimedCanceledFuture`, `createTimedExceptionFuture`, and `createTimedFutureRef`), plus `onProperty`/`onPropertyFuture` timeouts.
> 
> **API cleanup & call-site updates.** Removes the deprecated `signalToFuture(..., unsigned long timeout)` overload, keeps the chrono-based timeout path, and updates tests/helpers to use chrono literals (e.g. `20ms`, `5s`) and duration-based constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9da0e9d00e23bbb0d93ccdb3a5c1d4b795667a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->